### PR TITLE
Fix nyc reporter config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,4 @@ jobs:
 
       - run:
           name: Test
-          command: npm run test
+          command: npm run test && ./node_modules/codecov/bin/codecov

--- a/.nycrc
+++ b/.nycrc
@@ -1,18 +1,16 @@
 {
-  "nyc": {
-    "check-coverage": true,
-    "per-file": true,
-    "lines": 100,
-    "statements": 100,
-    "functions": 100,
-    "branches": 100,
-    "include": [
-      "test/**/*-test.js"
-    ],
-    "reporter": [
-      "lcov",
-      "text-summary",
-      "html"
-    ]
-  }
+  "check-coverage": true,
+  "per-file": true,
+  "lines": 100,
+  "statements": 100,
+  "functions": 100,
+  "branches": 100,
+  "include": [
+    "src/**/*.js"
+  ],
+  "reporter": [
+    "lcov",
+    "text-summary",
+    "html"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "./node_modules/gulp/bin/gulp.js build",
-    "test": "nyc ./node_modules/.bin/mocha && ./node_modules/codecov/bin/codecov",
+    "test": "./node_modules/.bin/nyc ./node_modules/.bin/mocha",
     "prepublishOnly": "npm run build"
   },
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",


### PR DESCRIPTION
- The key `nyc` does not exist in the `.nycrc` file.
- Running Codecov only for builds ran in CI.
